### PR TITLE
Issue380

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,11 @@
+29-Oct-2017 Fixes #380. Eliminating 'lock (this)' expressions and hardening Xcode generation thread safety. THIS IS A BREAKING CHANGE.
+
+'lock (this)' is considered bad for synchronisation, as the caller may also lock the object. Instances of these have been eliminated, either by replacing with a reduced scope lock on private only objects, or using System.Lazy<T> or System.Threading.LazyInitializer for thread-safe object initialization.
+
+Many properties of XcodeBuilder.Project that were public are now private, but with new public accessors containing appropriate synchronisation.
+
+XcodeBuilder.Target.Type is no longer public. The setter for this may have been used by external code, so this may cause compiler errors. There is now a public accessor, XcodeBuilder.Target.SetType() to use instead.
+
 27-Oct-2017 Fixes #373. Tightening up TokenizedString parsing APIs. THIS IS A BREAKING CHANGE.
 
 Parse() and ToString() used to do the same thing, but now they are different.

--- a/packages/C/bam/XCodeBuilder/XcodeAssembly.cs
+++ b/packages/C/bam/XCodeBuilder/XcodeAssembly.cs
@@ -53,7 +53,7 @@ namespace C
             // this is for stand-alone object files
             if (encapsulating == sender || encapsulating == (sender as Bam.Core.IChildModule).Parent)
             {
-                target.Type = XcodeBuilder.Target.EProductType.ObjFile;
+                target.SetType(XcodeBuilder.Target.EProductType.ObjFile);
                 var configuration = target.GetConfiguration(sender);
                 configuration.SetProductName(Bam.Core.TokenizedString.CreateVerbatim("${TARGET_NAME}"));
                 (sender.Settings as XcodeProjectProcessor.IConvertToProject).Convert(sender, configuration);

--- a/packages/C/bam/XCodeBuilder/XcodeCompilation.cs
+++ b/packages/C/bam/XCodeBuilder/XcodeCompilation.cs
@@ -71,7 +71,7 @@ namespace C
             // this is for stand-alone object files
             if (encapsulating == sender || encapsulating == (sender as Bam.Core.IChildModule).Parent)
             {
-                target.Type = XcodeBuilder.Target.EProductType.ObjFile;
+                target.SetType(XcodeBuilder.Target.EProductType.ObjFile);
                 var configuration = target.GetConfiguration(sender);
                 configuration.SetProductName(Bam.Core.TokenizedString.CreateVerbatim("${TARGET_NAME}"));
                 (sender.Settings as XcodeProjectProcessor.IConvertToProject).Convert(sender, configuration);

--- a/packages/C/bam/XCodeBuilder/XcodeHeaderLibrary.cs
+++ b/packages/C/bam/XCodeBuilder/XcodeHeaderLibrary.cs
@@ -45,7 +45,7 @@ namespace C
 
             var workspace = Bam.Core.Graph.Instance.MetaData as XcodeBuilder.WorkspaceMeta;
             var target = workspace.EnsureTargetExists(sender);
-            target.Type = XcodeBuilder.Target.EProductType.Utility;
+            target.SetType(XcodeBuilder.Target.EProductType.Utility);
             var configuration = target.GetConfiguration(sender);
             configuration.SetProductName(Bam.Core.TokenizedString.CreateVerbatim("${TARGET_NAME}"));
 

--- a/packages/MakeFileBuilder/bam/Scripts/MakeFileCommonMetaData.cs
+++ b/packages/MakeFileBuilder/bam/Scripts/MakeFileCommonMetaData.cs
@@ -71,7 +71,7 @@ namespace MakeFileBuilder
         ExtendEnvironmentVariables(
             System.Collections.Generic.Dictionary<string, Bam.Core.TokenizedStringArray> import)
         {
-            lock (this)
+            lock (this.Environment)
             {
                 foreach (var env in import)
                 {
@@ -96,7 +96,7 @@ namespace MakeFileBuilder
         AddDirectory(
             string path)
         {
-            lock (this)
+            lock (this.Directories)
             {
                 this.Directories.AddUnique(path);
             }

--- a/packages/Publisher/bam/XcodeBuilder/XcodeCollatedObject.cs
+++ b/packages/Publisher/bam/XcodeBuilder/XcodeCollatedObject.cs
@@ -63,7 +63,7 @@ namespace Publisher
                     var target = workspace.EnsureTargetExists(sender.SourceModule);
                     var configuration = target.GetConfiguration(sender.SourceModule);
 
-                    target.Type = XcodeBuilder.Target.EProductType.Utility;
+                    target.SetType(XcodeBuilder.Target.EProductType.Utility);
                     configuration.SetProductName(sender.SourceModule.Macros["modulename"]);
                     //Bam.Core.Log.MessageAll("Configuration {0} for {1}", configuration.Name, sender.SourceModule.ToString());
                 }
@@ -89,7 +89,7 @@ namespace Publisher
                 }
 
                 var target = sender.SourceModule.MetaData as XcodeBuilder.Target;
-                if (target.Type != XcodeBuilder.Target.EProductType.Utility)
+                if (!target.isUtilityType)
                 {
                     commands.Add(System.String.Format("{0} {1} $CONFIGURATION_BUILD_DIR/$EXECUTABLE_NAME {2} {3}",
                         CommandLineProcessor.Processor.StringifyTool(sender.Tool as Bam.Core.ICommandLineTool),
@@ -108,7 +108,7 @@ namespace Publisher
                 }
 
                 var configuration = target.GetConfiguration(sender.SourceModule);
-                if (target.Type != XcodeBuilder.Target.EProductType.Utility)
+                if (!target.isUtilityType)
                 {
                     target.AddPostBuildCommands(commands, configuration);
                 }
@@ -128,7 +128,7 @@ namespace Publisher
                 {
                     destinationFolder = "$CONFIGURATION_BUILD_DIR/$EXECUTABLE_FOLDER_PATH";
                 }
-                if (target.Type == XcodeBuilder.Target.EProductType.Utility)
+                if (target.isUtilityType)
                 {
                     destinationFolder = destinationPath;
                 }
@@ -178,7 +178,7 @@ namespace Publisher
                 }
 
                 var configuration = target.GetConfiguration(sender.Reference.SourceModule);
-                if (target.Type != XcodeBuilder.Target.EProductType.Utility)
+                if (!target.isUtilityType)
                 {
                     target.AddPostBuildCommands(commands, configuration);
                 }

--- a/packages/VSSolutionBuilder/bam/Scripts/VSProject.cs
+++ b/packages/VSSolutionBuilder/bam/Scripts/VSProject.cs
@@ -144,72 +144,82 @@ namespace VSSolutionBuilder
             }
         }
 
+        private void
+        AddToFilter(
+            VSSettingsGroup group)
+        {
+            lock (this.Filter)
+            {
+                this.Filter.AddFile(group);
+            }
+        }
+
         public void
         AddHeader(
             VSSettingsGroup header)
         {
-            lock (this)
+            lock (this.Headers)
             {
                 this.Headers.AddUnique(header);
-                this.Filter.AddFile(header);
             }
+            AddToFilter(header);
         }
 
         public void
         AddSource(
             VSSettingsGroup source)
         {
-            lock (this)
+            lock (this.Sources)
             {
                 this.Sources.AddUnique(source);
-                this.Filter.AddFile(source);
             }
+            AddToFilter(source);
         }
 
         public void
         AddOtherFile(
             VSSettingsGroup other)
         {
-            lock (this)
+            lock (this.Others)
             {
                 this.Others.AddUnique(other);
-                this.Filter.AddFile(other);
             }
+            AddToFilter(other);
         }
 
         public void
         AddResourceFile(
             VSSettingsGroup other)
         {
-            lock (this)
+            lock (this.Resources)
             {
                 this.Resources.AddUnique(other);
-                this.Filter.AddFile(other);
             }
+            AddToFilter(other);
         }
 
         public void
         AddAssemblyFile(
             VSSettingsGroup other)
         {
-            lock (this)
+            lock (this.AssemblyFiles)
             {
                 this.AssemblyFiles.AddUnique(other);
-                this.Filter.AddFile(other);
             }
+            AddToFilter(other);
         }
 
         public void
         AddOrderOnlyDependency(
             VSProject dependentProject)
         {
-            lock (this)
+            if (this.LinkDependentProjects.Contains(dependentProject))
             {
-                if (this.LinkDependentProjects.Contains(dependentProject))
-                {
-                    Bam.Core.Log.DebugMessage("Project {0} already contains a link dependency on {1}. There is no need to add it as an order-only dependency.", this.ProjectPath, dependentProject.ProjectPath);
-                    return;
-                }
+                Bam.Core.Log.DebugMessage("Project {0} already contains a link dependency on {1}. There is no need to add it as an order-only dependency.", this.ProjectPath, dependentProject.ProjectPath);
+                return;
+            }
+            lock (this.OrderOnlyDependentProjects)
+            {
                 this.OrderOnlyDependentProjects.AddUnique(dependentProject);
             }
         }
@@ -218,13 +228,13 @@ namespace VSSolutionBuilder
         AddLinkDependency(
             VSProject dependentProject)
         {
-            lock (this)
+            if (this.OrderOnlyDependentProjects.Contains(dependentProject))
             {
-                if (this.OrderOnlyDependentProjects.Contains(dependentProject))
-                {
-                    Bam.Core.Log.DebugMessage("Project {0} already contains an order-only dependency on {1}. Removing the order-only dependency, and upgrading to a link dependency.", this.ProjectPath, dependentProject.ProjectPath);
-                    this.OrderOnlyDependentProjects.Remove(dependentProject);
-                }
+                Bam.Core.Log.DebugMessage("Project {0} already contains an order-only dependency on {1}. Removing the order-only dependency, and upgrading to a link dependency.", this.ProjectPath, dependentProject.ProjectPath);
+                this.OrderOnlyDependentProjects.Remove(dependentProject);
+            }
+            lock (this.LinkDependentProjects)
+            {
                 this.LinkDependentProjects.AddUnique(dependentProject);
             }
         }

--- a/packages/VSSolutionBuilder/bam/Scripts/VSSolutionFolder.cs
+++ b/packages/VSSolutionBuilder/bam/Scripts/VSSolutionFolder.cs
@@ -49,10 +49,34 @@ namespace VSSolutionBuilder
             private set;
         }
 
-        public Bam.Core.Array<HasGuid> NestedEntities
+        private Bam.Core.Array<HasGuid> NestedEntities
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendNestedEntity(
+            HasGuid entity)
+        {
+            lock (this.NestedEntities)
+            {
+                this.NestedEntities.AddUnique(entity);
+            }
+        }
+
+        public void
+        Serialize(
+            System.Text.StringBuilder content,
+            int indentLevel)
+        {
+            var indent = new string('\t', indentLevel);
+            foreach (var nested in this.NestedEntities)
+            {
+                content.AppendFormat("{0}{1} = {2}", indent, nested.GuidString, this.GuidString);
+                content.AppendLine();
+            }
+
         }
     }
 }

--- a/packages/XcodeBuilder/bam/Scripts/Configuration.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Configuration.cs
@@ -54,16 +54,36 @@ namespace XcodeBuilder
             private set;
         }
 
-        public Bam.Core.StringArray PreBuildCommands
+        private Bam.Core.StringArray PreBuildCommands
         {
             get;
-            private set;
+            set;
         }
 
-        public Bam.Core.StringArray PostBuildCommands
+        public void
+        appendPreBuildCommands(
+            Bam.Core.StringArray commands)
+        {
+            lock (this.PreBuildCommands)
+            {
+                this.PreBuildCommands.AddRange(commands);
+            }
+        }
+
+        private Bam.Core.StringArray PostBuildCommands
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendPostBuildCommands(
+            Bam.Core.StringArray commands)
+        {
+            lock (this.PostBuildCommands)
+            {
+                this.PostBuildCommands.AddRange(commands);
+            }
         }
 
         public Bam.Core.Array<BuildFile> BuildFiles
@@ -129,6 +149,35 @@ namespace XcodeBuilder
             text.AppendLine();
             text.AppendFormat("{0}}};", indent);
             text.AppendLine();
+        }
+
+        private void
+        SerializeCommmandList(
+            System.Text.StringBuilder text,
+            int indentLevel,
+            Bam.Core.StringArray commandList)
+        {
+            var indent = new string(' ', 2 * indentLevel);
+            foreach (var line in commandList)
+            {
+                text.AppendFormat("{0}{1}\\n", indent, line.Replace("\"", "\\\""));
+            }
+        }
+
+        public void
+        SerializePreBuildCommands(
+            System.Text.StringBuilder text,
+            int indentLevel)
+        {
+            this.SerializeCommmandList(text, indentLevel, this.PreBuildCommands);
+        }
+
+        public void
+        SerializePostBuildCommands(
+            System.Text.StringBuilder text,
+            int indentLevel)
+        {
+            this.SerializeCommmandList(text, indentLevel, this.PostBuildCommands);
         }
     }
 }

--- a/packages/XcodeBuilder/bam/Scripts/ConfigurationList.cs
+++ b/packages/XcodeBuilder/bam/Scripts/ConfigurationList.cs
@@ -40,7 +40,7 @@ namespace XcodeBuilder
             base(parent.Project, null, "XCConfigurationList", parent.GUID)
         {
             this.Parent = parent;
-            this.Configurations = new System.Collections.Generic.List<Configuration>();
+            this.Configurations = new Bam.Core.Array<Configuration>();
         }
 
         public Configuration this[int index]
@@ -57,7 +57,7 @@ namespace XcodeBuilder
             private set;
         }
 
-        private System.Collections.Generic.List<Configuration> Configurations
+        private Bam.Core.Array<Configuration> Configurations
         {
             get;
             set;

--- a/packages/XcodeBuilder/bam/Scripts/ContainerItemProxy.cs
+++ b/packages/XcodeBuilder/bam/Scripts/ContainerItemProxy.cs
@@ -41,7 +41,7 @@ namespace XcodeBuilder
         {
             this.ContainerPortal = portal;
             this.RemoteName = null;
-            project.ContainerItemProxies.AddUnique(this);
+            project.appendContainerItemProxy(this);
         }
 
         // for NativeTargets in a different Project

--- a/packages/XcodeBuilder/bam/Scripts/Group.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Group.cs
@@ -40,7 +40,7 @@ namespace XcodeBuilder
             base(project, name, "PBXGroup")
         {
             this.SourceTree = "<group>";
-            this.Children = new System.Collections.Generic.List<Object>();
+            this.Children = new Bam.Core.Array<Object>();
         }
 
         public Group(
@@ -51,7 +51,7 @@ namespace XcodeBuilder
             base(target.Project, name, "PBXGroup", fullPath.ToString())
         {
             this.SourceTree = "<group>";
-            this.Children = new System.Collections.Generic.List<Object>();
+            this.Children = new Bam.Core.Array<Object>();
         }
 
         public Group(
@@ -62,7 +62,7 @@ namespace XcodeBuilder
             base(project, name, "PBXGroup", children.ToList().ConvertAll(item => item.GUID).ToArray())
         {
             this.SourceTree = "<group>";
-            this.Children = new System.Collections.Generic.List<Object>();
+            this.Children = new Bam.Core.Array<Object>();
             foreach (var child in children)
             {
                 this.AddChild(child);
@@ -75,7 +75,7 @@ namespace XcodeBuilder
             private set;
         }
 
-        public System.Collections.Generic.List<Object> Children
+        public Bam.Core.Array<Object> Children
         {
             get;
             private set;

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -86,31 +86,34 @@ namespace XcodeBuilder
             string guid,
             Object objectForGuid)
         {
-            if (this.ExistingGUIDs.ContainsKey(guid))
+            lock (this.ExistingGUIDs)
             {
-                // enable the log code path to view all clashes, rather than aborting on the first
+                if (this.ExistingGUIDs.ContainsKey(guid))
+                {
+                    // enable the log code path to view all clashes, rather than aborting on the first
 #if true
-                throw new Bam.Core.Exception("GUID collision {6} between\n\t{0}({1})[in {2}]\n\t{3}({4})[in {5}]",
-                                             objectForGuid.Name,
-                                             objectForGuid.IsA,
-                                             objectForGuid.Project.Name,
-                                             this.ExistingGUIDs[guid].Name,
-                                             this.ExistingGUIDs[guid].IsA,
-                                             this.ExistingGUIDs[guid].Project.Name,
-                                             guid);
+                    throw new Bam.Core.Exception("GUID collision {6} between\n\t{0}({1})[in {2}]\n\t{3}({4})[in {5}]",
+                                                 objectForGuid.Name,
+                                                 objectForGuid.IsA,
+                                                 objectForGuid.Project.Name,
+                                                 this.ExistingGUIDs[guid].Name,
+                                                 this.ExistingGUIDs[guid].IsA,
+                                                 this.ExistingGUIDs[guid].Project.Name,
+                                                 guid);
 #else
-                Bam.Core.Log.MessageAll("GUID collision {6} between\n\t{0}({1})[in {2}]\n\t{3}({4})[in {5}]",
-                                             objectForGuid.Name,
-                                             objectForGuid.IsA,
-                                             objectForGuid.Project.Name,
-                                             this.ExistingGUIDs[guid].Name,
-                                             this.ExistingGUIDs[guid].IsA,
-                                             this.ExistingGUIDs[guid].Project.Name,
-                                             guid);
-                return;
-                #endif
+                    Bam.Core.Log.MessageAll("GUID collision {6} between\n\t{0}({1})[in {2}]\n\t{3}({4})[in {5}]",
+                                                 objectForGuid.Name,
+                                                 objectForGuid.IsA,
+                                                 objectForGuid.Project.Name,
+                                                 this.ExistingGUIDs[guid].Name,
+                                                 this.ExistingGUIDs[guid].IsA,
+                                                 this.ExistingGUIDs[guid].Project.Name,
+                                                 guid);
+                    return;
+#endif
+                }
+                this.ExistingGUIDs.Add(guid, objectForGuid);
             }
-            this.ExistingGUIDs.Add(guid, objectForGuid);
         }
 
         public string SourceRoot

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -71,8 +71,8 @@ namespace XcodeBuilder
             this.TargetDependencies = new Bam.Core.Array<TargetDependency>();
             this.ProjectReferences = new System.Collections.Generic.Dictionary<Group, FileReference>();
 
-            this.Groups.Add(new Group(this, null)); // main group
-            this.Groups.Add(new Group(this, "Products")); // product ref group
+            this.appendGroup(new Group(this, null)); // main group
+            this.appendGroup(new Group(this, "Products")); // product ref group
             this.MainGroup.AddChild(this.ProductRefGroup);
 
             var configList = new ConfigurationList(this);
@@ -172,10 +172,27 @@ namespace XcodeBuilder
             set;
         }
 
-        public Bam.Core.Array<Group> Groups
+        private Bam.Core.Array<Group> Groups
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendGroup(
+            Group group)
+        {
+            lock (this.Groups)
+            {
+                this.Groups.Add(group);
+            }
+        }
+
+        public Group
+        groupWithChild(
+            ReferenceProxy proxy)
+        {
+            return this.Groups.FirstOrDefault(item => item.Children.Contains(proxy));
         }
 
         public System.Collections.Generic.Dictionary<string, Group> GroupMap
@@ -311,6 +328,7 @@ namespace XcodeBuilder
         {
             get
             {
+                // order is assumed - added in the constructor
                 return this.Groups[0];
             }
         }
@@ -319,6 +337,7 @@ namespace XcodeBuilder
         {
             get
             {
+                // order is assumed - added in the constructor
                 return this.Groups[1];
             }
         }
@@ -586,7 +605,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXFrameworksBuildPhase section */");
                 text.AppendLine();
             }
-            if (this.Groups.Count > 0)
+            if (this.Groups.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXGroup section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -212,10 +212,20 @@ namespace XcodeBuilder
             private set;
         }
 
-        public Bam.Core.Array<SourcesBuildPhase> SourcesBuildPhases
+        private Bam.Core.Array<SourcesBuildPhase> SourcesBuildPhases
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendSourcesBuildPhase(
+            SourcesBuildPhase phase)
+        {
+            lock (this.SourcesBuildPhases)
+            {
+                this.SourcesBuildPhases.Add(phase);
+            }
         }
 
         private Bam.Core.Array<FrameworksBuildPhase> FrameworksBuildPhases
@@ -557,7 +567,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXFileReference section */");
                 text.AppendLine();
             }
-            if (this.FrameworksBuildPhases.Any()
+            if (this.FrameworksBuildPhases.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXFrameworksBuildPhase section */");
@@ -618,7 +628,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXShellScriptBuildPhase section */");
                 text.AppendLine();
             }
-            if (this.SourcesBuildPhases.Count > 0)
+            if (this.SourcesBuildPhases.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXSourcesBuildPhase section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -323,10 +323,25 @@ namespace XcodeBuilder
                 (item.ContainerPortal == containerPortal) && (item.Remote == remote));
         }
 
-        public Bam.Core.Array<ReferenceProxy> ReferenceProxies
+        private Bam.Core.Array<ReferenceProxy> ReferenceProxies
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendReferenceProxy(
+            ReferenceProxy proxy)
+        {
+            // no lock required, added in serial code
+            this.ReferenceProxies.Add(proxy);
+        }
+
+        public ReferenceProxy
+        getReferenceProxyForRemoteRef(
+            ContainerItemProxy remoteRef)
+        {
+            return this.ReferenceProxies.FirstOrDefault(item => item.RemoteRef == remoteRef);
         }
 
         public Bam.Core.Array<TargetDependency> TargetDependencies
@@ -647,7 +662,7 @@ namespace XcodeBuilder
                 text.AppendLine();
             }
             this.InternalSerialize(text, indentLevel); //this is the PBXProject :)
-            if (this.ReferenceProxies.Count > 0)
+            if (this.ReferenceProxies.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXReferenceProxy section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -260,10 +260,10 @@ namespace XcodeBuilder
             }
         }
 
-        public Bam.Core.Array<CopyFilesBuildPhase> CopyFilesBuildPhases
+        private Bam.Core.Array<CopyFilesBuildPhase> CopyFilesBuildPhases
         {
             get;
-            private set;
+            set;
         }
 
         private Bam.Core.Array<ContainerItemProxy> ContainerItemProxies
@@ -560,7 +560,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXContainerItemProxy section */");
                 text.AppendLine();
             }
-            if (this.CopyFilesBuildPhases.Count > 0)
+            if (this.CopyFilesBuildPhases.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXCopyFilesBuildPhase section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -221,10 +221,20 @@ namespace XcodeBuilder
             private set;
         }
 
-        public Bam.Core.Array<ShellScriptBuildPhase> ShellScriptsBuildPhases
+        private Bam.Core.Array<ShellScriptBuildPhase> ShellScriptsBuildPhases
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendShellScriptsBuildPhase(
+            ShellScriptBuildPhase phase)
+        {
+            lock (this.ShellScriptsBuildPhases)
+            {
+                this.ShellScriptsBuildPhases.Add(phase);
+            }
         }
 
         public Bam.Core.Array<CopyFilesBuildPhase> CopyFilesBuildPhases
@@ -583,7 +593,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXReferenceProxy section */");
                 text.AppendLine();
             }
-            if (this.ShellScriptsBuildPhases.Count > 0)
+            if (this.ShellScriptsBuildPhases.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXShellScriptBuildPhase section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -330,17 +330,7 @@ namespace XcodeBuilder
             bool explicitType = true,
             FileReference.ESourceTree sourceTree = FileReference.ESourceTree.NA)
         {
-            lock (this.FileReferences)
-            {
-                var existingFileRef = this.FileReferences.FirstOrDefault(item => item.Path.ToString().Equals(path.ToString()));
-                if (null != existingFileRef)
-                {
-                    return existingFileRef;
-                }
-                var newFileRef = new FileReference(path, type, this, explicitType, sourceTree);
-                this.FileReferences.Add(newFileRef);
-                return newFileRef;
-            }
+            return this.EnsureFileReferenceExists(path, null, type, explicitType, sourceTree);
         }
 
         public FileReference
@@ -572,7 +562,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXCopyFilesBuildPhase section */");
                 text.AppendLine();
             }
-            if (this.FileReferences.Count > 0)
+            if (this.FileReferences.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXFileReference section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -520,8 +520,12 @@ namespace XcodeBuilder
                 }
                 foreach (var config in target.ConfigurationList)
                 {
-                    var diff = target.SourcesBuildPhase.BuildFiles.Complement(config.BuildFiles);
-                    if (diff.Count > 0)
+                    if (!target.SourcesBuildPhase.IsValueCreated)
+                    {
+                        continue;
+                    }
+                    var diff = target.SourcesBuildPhase.Value.BuildFiles.Complement(config.BuildFiles);
+                    if (diff.Any())
                     {
                         var excluded = new MultiConfigurationValue();
                         foreach (var file in diff)

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -218,10 +218,20 @@ namespace XcodeBuilder
             private set;
         }
 
-        public Bam.Core.Array<FrameworksBuildPhase> FrameworksBuildPhases
+        private Bam.Core.Array<FrameworksBuildPhase> FrameworksBuildPhases
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendFrameworksBuildPhase(
+            FrameworksBuildPhase phase)
+        {
+            lock (this.FrameworksBuildPhases)
+            {
+                this.FrameworksBuildPhases.Add(phase);
+            }
         }
 
         private Bam.Core.Array<ShellScriptBuildPhase> ShellScriptsBuildPhases
@@ -547,7 +557,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXFileReference section */");
                 text.AppendLine();
             }
-            if (this.FrameworksBuildPhases.Count > 0)
+            if (this.FrameworksBuildPhases.Any()
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXFrameworksBuildPhase section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -181,10 +181,20 @@ namespace XcodeBuilder
             private set;
         }
 
-        public Bam.Core.Array<Configuration> AllConfigurations
+        private Bam.Core.Array<Configuration> AllConfigurations
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendAllConfigurations(
+            Configuration config)
+        {
+            lock (this.AllConfigurations)
+            {
+                this.AllConfigurations.Add(config);
+            }
         }
 
         public System.Collections.Generic.Dictionary<Bam.Core.EConfiguration, Configuration> ProjectConfigurations
@@ -361,7 +371,7 @@ namespace XcodeBuilder
                 projectConfig["CONFIGURATION_BUILD_DIR"] = new UniqueConfigurationValue("$(SYMROOT)/$(CONFIGURATION)");
 
                 this.ConfigurationLists[0].AddConfiguration(projectConfig);
-                this.AllConfigurations.Add(projectConfig);
+                this.appendAllConfigurations(projectConfig);
                 this.ProjectConfigurations.Add(config, projectConfig);
             }
         }
@@ -609,7 +619,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXTargetDependency section */");
                 text.AppendLine();
             }
-            if (this.AllConfigurations.Count > 0)
+            if (this.AllConfigurations.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin XCBuildConfiguration section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -344,10 +344,34 @@ namespace XcodeBuilder
             return this.ReferenceProxies.FirstOrDefault(item => item.RemoteRef == remoteRef);
         }
 
-        public Bam.Core.Array<TargetDependency> TargetDependencies
+        private Bam.Core.Array<TargetDependency> TargetDependencies
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendTargetDependency(
+            TargetDependency dep)
+        {
+            // no lock required, as this is added in serial code
+            this.TargetDependencies.Add(dep);
+        }
+
+        public TargetDependency
+        getTargetDependency(
+            Target target,
+            ContainerItemProxy proxy)
+        {
+            return this.TargetDependencies.FirstOrDefault(item => item.Dependency == target && item.Proxy == proxy);
+        }
+
+        public TargetDependency
+        getTargetDependency(
+            string name,
+            ContainerItemProxy proxy)
+        {
+            return this.TargetDependencies.FirstOrDefault(item => item.Dependency == null && item.Name == name && item.Proxy == proxy);
         }
 
         public System.Collections.Generic.Dictionary<Group, FileReference> ProjectReferences
@@ -698,7 +722,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXSourcesBuildPhase section */");
                 text.AppendLine();
             }
-            if (this.TargetDependencies.Count > 0)
+            if (this.TargetDependencies.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXTargetDependency section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -266,10 +266,27 @@ namespace XcodeBuilder
             private set;
         }
 
-        public Bam.Core.Array<ContainerItemProxy> ContainerItemProxies
+        private Bam.Core.Array<ContainerItemProxy> ContainerItemProxies
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendContainerItemProxy(
+            ContainerItemProxy proxy)
+        {
+            // these are only added in a single thread
+            this.ContainerItemProxies.AddUnique(proxy);
+        }
+
+        public ContainerItemProxy
+        getContainerItemProxy(
+            Object remote,
+            Object containerPortal)
+        {
+            return this.ContainerItemProxies.FirstOrDefault(item =>
+                (item.ContainerPortal == containerPortal) && (item.Remote == remote));
         }
 
         public Bam.Core.Array<ReferenceProxy> ReferenceProxies
@@ -519,7 +536,7 @@ namespace XcodeBuilder
             System.Text.StringBuilder text,
             int indentLevel)
         {
-            if (this.BuildFiles.Count > 0)
+            if (this.BuildFiles.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXBuildFile section */");
@@ -531,7 +548,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXBuildFile section */");
                 text.AppendLine();
             }
-            if (this.ContainerItemProxies.Count > 0)
+            if (this.ContainerItemProxies.Any())
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXContainerItemProxy section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -154,10 +154,27 @@ namespace XcodeBuilder
             private set;
         }
 
-        public System.Collections.Generic.Dictionary<System.Type, Target> Targets
+        private System.Collections.Generic.Dictionary<System.Type, Target> Targets
         {
             get;
-            private set;
+            set;
+        }
+
+        public void
+        appendTarget(
+            Target target)
+        {
+            // Note: this lock probably not required, as it's only invoked from within another lock
+            lock (this.Targets)
+            {
+                this.Targets.Add(target.Module.GetType(), target);
+            }
+        }
+
+        public System.Collections.Generic.IReadOnlyList<Target>
+        getTargetList()
+        {
+            return this.Targets.Values.ToList();
         }
 
         private Bam.Core.Array<FileReference> FileReferences
@@ -617,7 +634,7 @@ namespace XcodeBuilder
                 text.AppendFormat("/* End PBXGroup section */");
                 text.AppendLine();
             }
-            if (this.Targets.Count > 0) // NativeTargets
+            if (this.Targets.Any()) // NativeTargets
             {
                 text.AppendLine();
                 text.AppendFormat("/* Begin PBXNativeTarget section */");

--- a/packages/XcodeBuilder/bam/Scripts/Project.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Project.cs
@@ -55,15 +55,15 @@ namespace XcodeBuilder
 
             this.Module = module;
             this.Targets = new System.Collections.Generic.Dictionary<System.Type, Target>();
-            this.FileReferences = new System.Collections.Generic.List<FileReference>();
-            this.BuildFiles = new System.Collections.Generic.List<BuildFile>();
-            this.Groups = new System.Collections.Generic.List<Group>();
+            this.FileReferences = new Bam.Core.Array<FileReference>();
+            this.BuildFiles = new Bam.Core.Array<BuildFile>();
+            this.Groups = new Bam.Core.Array<Group>();
             this.GroupMap = new System.Collections.Generic.Dictionary<string, Group>();
-            this.AllConfigurations = new System.Collections.Generic.List<Configuration>();
+            this.AllConfigurations = new Bam.Core.Array<Configuration>();
             this.ProjectConfigurations = new System.Collections.Generic.Dictionary<Bam.Core.EConfiguration, Configuration>();
-            this.ConfigurationLists = new System.Collections.Generic.List<ConfigurationList>();
-            this.SourcesBuildPhases = new System.Collections.Generic.List<SourcesBuildPhase>();
-            this.FrameworksBuildPhases = new System.Collections.Generic.List<FrameworksBuildPhase>();
+            this.ConfigurationLists = new Bam.Core.Array<ConfigurationList>();
+            this.SourcesBuildPhases = new Bam.Core.Array<SourcesBuildPhase>();
+            this.FrameworksBuildPhases = new Bam.Core.Array<FrameworksBuildPhase>();
             this.ShellScriptsBuildPhases = new Bam.Core.Array<ShellScriptBuildPhase>();
             this.CopyFilesBuildPhases = new Bam.Core.Array<CopyFilesBuildPhase>();
             this.ContainerItemProxies = new Bam.Core.Array<ContainerItemProxy>();
@@ -157,19 +157,19 @@ namespace XcodeBuilder
             private set;
         }
 
-        private System.Collections.Generic.List<FileReference> FileReferences
+        private Bam.Core.Array<FileReference> FileReferences
         {
             get;
             set;
         }
 
-        private System.Collections.Generic.List<BuildFile> BuildFiles
+        private Bam.Core.Array<BuildFile> BuildFiles
         {
             get;
             set;
         }
 
-        public System.Collections.Generic.List<Group> Groups
+        public Bam.Core.Array<Group> Groups
         {
             get;
             private set;
@@ -181,7 +181,7 @@ namespace XcodeBuilder
             private set;
         }
 
-        public System.Collections.Generic.List<Configuration> AllConfigurations
+        public Bam.Core.Array<Configuration> AllConfigurations
         {
             get;
             private set;
@@ -193,19 +193,19 @@ namespace XcodeBuilder
             private set;
         }
 
-        public System.Collections.Generic.List<ConfigurationList> ConfigurationLists
+        public Bam.Core.Array<ConfigurationList> ConfigurationLists
         {
             get;
             private set;
         }
 
-        public System.Collections.Generic.List<SourcesBuildPhase> SourcesBuildPhases
+        public Bam.Core.Array<SourcesBuildPhase> SourcesBuildPhases
         {
             get;
             private set;
         }
 
-        public System.Collections.Generic.List<FrameworksBuildPhase> FrameworksBuildPhases
+        public Bam.Core.Array<FrameworksBuildPhase> FrameworksBuildPhases
         {
             get;
             private set;

--- a/packages/XcodeBuilder/bam/Scripts/ProjectSchemeCache.cs
+++ b/packages/XcodeBuilder/bam/Scripts/ProjectSchemeCache.cs
@@ -39,14 +39,14 @@ namespace XcodeBuilder
             this.Project = project;
             this.SchemeDocuments = new System.Collections.Generic.Dictionary<string, System.Xml.XmlDocument>();
 
-            foreach (var target in project.Targets)
+            foreach (var target in project.getTargetList())
             {
-                var schemeFilename = System.String.Format("{0}.xcscheme", target.Value.Name);
+                var schemeFilename = System.String.Format("{0}.xcscheme", target.Name);
                 var schemePathname = System.String.Format("{0}/xcuserdata/{1}.xcuserdatad/xcschemes/{2}",
                         project.ProjectDir,
                         System.Environment.GetEnvironmentVariable("USER"),
                         schemeFilename);
-                var doc = this.CreateSchemePlist(target.Value);
+                var doc = this.CreateSchemePlist(target);
                 this.SchemeDocuments.Add(schemePathname, doc);
             }
             this.CreateManagementPlist();

--- a/packages/XcodeBuilder/bam/Scripts/ProjectSchemeCache.cs
+++ b/packages/XcodeBuilder/bam/Scripts/ProjectSchemeCache.cs
@@ -82,9 +82,9 @@ namespace XcodeBuilder
             {
                 buildableReference.SetAttribute("BuildableIdentifier", "primary");
                 buildableReference.SetAttribute("BlueprintIdentifier", target.GUID);
-                if (null != target.FileReference)
+                if (null != target.getFileReference())
                 {
-                    buildableReference.SetAttribute("BuildableName", target.FileReference.Name);
+                    buildableReference.SetAttribute("BuildableName", target.getFileReference().Name);
                 }
                 buildableReference.SetAttribute("BlueprintName", target.Name);
                 if (target.Project.ProjectDir == this.Project.ProjectDir)
@@ -160,10 +160,10 @@ namespace XcodeBuilder
 
                 buildableRefEl.SetAttribute("BuildableIdentifier", "primary");
 
-                if (null != target.FileReference)
+                if (null != target.getFileReference())
                 {
                     buildableRefEl.SetAttribute("BlueprintIdentifier", target.GUID);
-                    buildableRefEl.SetAttribute("BuildableName", target.FileReference.Name);
+                    buildableRefEl.SetAttribute("BuildableName", target.getFileReference().Name);
                     buildableRefEl.SetAttribute("BlueprintName", target.Name);
                 }
 

--- a/packages/XcodeBuilder/bam/Scripts/ReferenceProxy.cs
+++ b/packages/XcodeBuilder/bam/Scripts/ReferenceProxy.cs
@@ -46,7 +46,7 @@ namespace XcodeBuilder
             this.RemoteRef = remoteRef;
             this.SourceTree = sourceTree;
 
-            project.ReferenceProxies.AddUnique(this);
+            project.appendReferenceProxy(this);
         }
 
         public FileReference.EFileType FileType

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -280,6 +280,7 @@ namespace XcodeBuilder
         {
             lock (this)
             {
+                // TODO: candidate for System.Lazy
                 if (null == this.SourcesBuildPhase)
                 {
                     this.SourcesBuildPhase = new SourcesBuildPhase(this);
@@ -288,7 +289,7 @@ namespace XcodeBuilder
                         this.BuildPhases = new Bam.Core.Array<BuildPhase>();
                     }
                     this.BuildPhases.Add(this.SourcesBuildPhase);
-                    this.Project.SourcesBuildPhases.Add(this.SourcesBuildPhase);
+                    this.Project.appendSourcesBuildPhase(this.SourcesBuildPhase);
                 }
 
                 var buildFile = this.EnsureBuildFileExists(path, type);

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -400,8 +400,7 @@ namespace XcodeBuilder
             {
                 if (this.Project == depTarget.Project)
                 {
-                    var nativeTargetItemProxy = this.Project.ContainerItemProxies.FirstOrDefault(
-                        item => (item.ContainerPortal == this.Project) && (item.Remote == depTarget));
+                    var nativeTargetItemProxy = this.Project.getContainerItemProxy(depTarget, depTarget.Project);
                     if (null == nativeTargetItemProxy)
                     {
                         nativeTargetItemProxy = new ContainerItemProxy(this.Project, depTarget);
@@ -446,8 +445,7 @@ namespace XcodeBuilder
 
                     // need a ContainerItemProxy for the dependent NativeTarget
                     // which is associated with a local PBXTargetDependency
-                    var nativeTargetItemProxy = this.Project.ContainerItemProxies.FirstOrDefault(
-                        item => (item.ContainerPortal == dependentProjectFileRef) && (item.Remote == depTarget));
+                    var nativeTargetItemProxy = this.Project.getContainerItemProxy(depTarget, dependentProjectFileRef);
                     if (null == nativeTargetItemProxy)
                     {
                         nativeTargetItemProxy = new ContainerItemProxy(this.Project, dependentProjectFileRef, depTarget);
@@ -466,8 +464,7 @@ namespace XcodeBuilder
 
                     // need a ContainerItemProxy for the filereference of the dependent NativeTarget
                     // which is associated with a local PBXReferenceProxy
-                    var dependentFileRefItemProxy = this.Project.ContainerItemProxies.FirstOrDefault(
-                        item => (item.ContainerPortal == dependentProjectFileRef) && (item.Remote == depTarget.FileReference));
+                    var dependentFileRefItemProxy = this.Project.getContainerItemProxy(depTarget.FileReference, dependentProjectFileRef);
                     if (null == dependentFileRefItemProxy)
                     {
                         // note, uses the name of the Target, not the FileReference

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -511,6 +511,7 @@ namespace XcodeBuilder
         {
             lock (this)
             {
+                // TODO: candidate for System.Lazy
                 if (null == this.PreBuildBuildPhase)
                 {
                     var preBuildBuildPhase = new ShellScriptBuildPhase(this, "Pre Build", (target) =>
@@ -527,7 +528,7 @@ namespace XcodeBuilder
                         }
                         return content.ToString();
                     });
-                    this.Project.ShellScriptsBuildPhases.Add(preBuildBuildPhase);
+                    this.Project.appendShellScriptsBuildPhase(preBuildBuildPhase);
                     this.PreBuildBuildPhase = preBuildBuildPhase;
                     // do not add PreBuildBuildPhase to this.BuildPhases, so that it can be serialized in the right order
                 }
@@ -543,6 +544,7 @@ namespace XcodeBuilder
         {
             lock (this)
             {
+                // TODO: candidate for System.Lazy
                 if (null == this.PostBuildBuildPhase)
                 {
                     var postBuildBuildPhase = new ShellScriptBuildPhase(this, "Post Build", (target) =>
@@ -559,7 +561,7 @@ namespace XcodeBuilder
                         }
                         return content.ToString();
                     });
-                    this.Project.ShellScriptsBuildPhases.Add(postBuildBuildPhase);
+                    this.Project.appendShellScriptsBuildPhase(postBuildBuildPhase);
                     this.PostBuildBuildPhase = postBuildBuildPhase;
                     // do not add PostBuildBuildPhase to this.BuildPhases, so that it can be serialized in the right order
                 }

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -408,8 +408,7 @@ namespace XcodeBuilder
 
                     // note that target dependencies can be shared in a project by many Targets
                     // but each Target needs a reference to it
-                    var dependency = this.Project.TargetDependencies.FirstOrDefault(
-                        item => (item.Dependency == depTarget) && (item.Proxy == nativeTargetItemProxy));
+                    var dependency = this.Project.getTargetDependency(depTarget, nativeTargetItemProxy);
                     if (null == dependency)
                     {
                         dependency = new TargetDependency(this.Project, depTarget, nativeTargetItemProxy);
@@ -453,8 +452,7 @@ namespace XcodeBuilder
 
                     // note that target dependencies can be shared in a project by many Targets
                     // but each Target needs a reference to it
-                    var targetDependency = this.Project.TargetDependencies.FirstOrDefault(
-                        item => (item.Dependency == null) && (item.Name == depTarget.Name) && (item.Proxy == nativeTargetItemProxy));
+                    var targetDependency = this.Project.getTargetDependency(depTarget.Name, nativeTargetItemProxy);
                     if (null == targetDependency)
                     {
                         // no 'target', but does have the name of the dependent

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -55,7 +55,7 @@ namespace XcodeBuilder
 
             var configList = new ConfigurationList(this);
             this.ConfigurationList = configList;
-            project.ConfigurationLists.Add(configList);
+            project.appendConfigurationList(configList);
 
             this.TargetDependencies = new Bam.Core.Array<TargetDependency>();
             this.ProposedTargetDependencies = new Bam.Core.Array<Target>();

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -165,7 +165,7 @@ namespace XcodeBuilder
                 {
                     return existingConfig;
                 }
-                var config = this.Project.EnsureTargetConfigurationExists(module, this);
+                var config = this.EnsureTargetConfigurationExists(module, this.Project);
                 return config;
             }
         }
@@ -683,6 +683,52 @@ namespace XcodeBuilder
             text.AppendLine();
             text.AppendFormat("{0}}};", indent);
             text.AppendLine();
+        }
+
+        private Configuration
+        EnsureTargetConfigurationExists(
+            Bam.Core.Module module,
+            Project project)
+        {
+            var configList = this.ConfigurationList;
+            lock (configList)
+            {
+                var config = module.BuildEnvironment.Configuration;
+                var existingConfig = configList.FirstOrDefault(item => item.Config == config);
+                if (null != existingConfig)
+                {
+                    return existingConfig;
+                }
+
+                // if a new target config is needed, then a new project config is needed too
+                project.EnsureProjectConfigurationExists(module);
+
+                var newConfig = new Configuration(module.BuildEnvironment.Configuration, project, this);
+                project.AllConfigurations.Add(newConfig);
+                configList.AddConfiguration(newConfig);
+
+                var clangMeta = Bam.Core.Graph.Instance.PackageMetaData<Clang.MetaData>("Clang");
+
+                // set which SDK to build against
+                newConfig["SDKROOT"] = new UniqueConfigurationValue(clangMeta.SDK);
+
+                // set the minimum version of OSX/iPhone to run against
+                var minVersionRegEx = new System.Text.RegularExpressions.Regex("^(?<Type>[a-z]+)(?<Version>[0-9.]+)$");
+                var match = minVersionRegEx.Match(clangMeta.MinimumVersionSupported);
+                if (!match.Groups["Type"].Success)
+                {
+                    throw new Bam.Core.Exception("Unable to extract SDK type from: '{0}'", clangMeta.MinimumVersionSupported);
+                }
+                if (!match.Groups["Version"].Success)
+                {
+                    throw new Bam.Core.Exception("Unable to extract SDK version from: '{0}'", clangMeta.MinimumVersionSupported);
+                }
+
+                var optionName = System.String.Format("{0}_DEPLOYMENT_TARGET", match.Groups["Type"].Value.ToUpper());
+                newConfig[optionName] = new UniqueConfigurationValue(match.Groups["Version"].Value);
+
+                return newConfig;
+            }
         }
     }
 }

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -288,10 +288,10 @@ namespace XcodeBuilder
         {
             lock (this.Project)
             {
-                var found = this.Project.GroupMap.FirstOrDefault(item => item.Key == path.ToString());
-                if (!found.Equals(default(System.Collections.Generic.KeyValuePair<string, Group>)))
+                var existingGroup = this.Project.getGroupForPath(path);
+                if (null != existingGroup)
                 {
-                    return found.Value;
+                    return existingGroup;
                 }
                 var basenameTS = this.Module.CreateTokenizedString("@basename($(0))", path);
                 if (!basenameTS.IsParsed)
@@ -301,7 +301,7 @@ namespace XcodeBuilder
                 var basename = basenameTS.ToString();
                 var group = new Group(this, basename, path);
                 this.Project.appendGroup(group);
-                this.Project.GroupMap.Add(path.ToString(), group);
+                this.Project.assignGroupToPath(path, group);
                 if (path.ToString().Contains(System.IO.Path.DirectorySeparatorChar))
                 {
                     var parent = this.Module.CreateTokenizedString("@dir($(0))", path);
@@ -514,12 +514,7 @@ namespace XcodeBuilder
                         this.Project.appendGroup(productRefGroup);
                     }
 
-                    var productRef = this.Project.ProjectReferences.FirstOrDefault(
-                        item => item.Key == productRefGroup);
-                    if (null == productRef.Key)
-                    {
-                        this.Project.ProjectReferences.Add(productRefGroup, dependentProjectFileRef);
-                    }
+                    this.Project.EnsureProjectReferenceExists(productRefGroup, dependentProjectFileRef);
                 }
             }
         }

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -303,12 +303,13 @@ namespace XcodeBuilder
         {
             lock (this)
             {
+                // TODO: can this be synchronized better?
                 if (null != this.FrameworksBuildPhase)
                 {
                     return;
                 }
                 var frameworks = new FrameworksBuildPhase(this);
-                this.Project.FrameworksBuildPhases.Add(frameworks);
+                this.Project.appendFrameworksBuildPhase(frameworks);
                 this.BuildPhases.Add(frameworks);
                 this.FrameworksBuildPhase = frameworks;
             }

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -471,8 +471,7 @@ namespace XcodeBuilder
                         dependentFileRefItemProxy = new ContainerItemProxy(this.Project, dependentProjectFileRef, depTarget.FileReference, depTarget.Name);
                     }
 
-                    var refProxy = this.Project.ReferenceProxies.FirstOrDefault(
-                        item => item.RemoteRef == dependentFileRefItemProxy);
+                    var refProxy = this.Project.getReferenceProxyForRemoteRef(dependentFileRefItemProxy);
                     if (null == refProxy)
                     {
                         refProxy = new ReferenceProxy(

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -234,7 +234,7 @@ namespace XcodeBuilder
                 }
                 var basename = basenameTS.ToString();
                 var group = new Group(this, basename, path);
-                this.Project.Groups.Add(group);
+                this.Project.appendGroup(group);
                 this.Project.GroupMap.Add(path.ToString(), group);
                 if (path.ToString().Contains(System.IO.Path.DirectorySeparatorChar))
                 {
@@ -485,12 +485,11 @@ namespace XcodeBuilder
 
                     // TODO: all PBXReferenceProxies could go into the same group
                     // but at the moment, a group is made for each
-                    var productRefGroup = this.Project.Groups.FirstOrDefault(
-                        item => item.Children.Contains(refProxy));
+                    var productRefGroup = this.Project.groupWithChild(refProxy);
                     if (null == productRefGroup)
                     {
                         productRefGroup = new Group(this.Project, "Products", refProxy);
-                        this.Project.Groups.Add(productRefGroup);
+                        this.Project.appendGroup(productRefGroup);
                     }
 
                     var productRef = this.Project.ProjectReferences.FirstOrDefault(

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -381,17 +381,14 @@ namespace XcodeBuilder
             string relativePath = null,
             bool explicitType = true)
         {
-            lock (this)
-            {
-                var sourceTree = (relativePath != null) ? FileReference.ESourceTree.SourceRoot : FileReference.ESourceTree.Absolute;
-                var fileRef = this.Project.EnsureFileReferenceExists(
-                    path,
-                    relativePath,
-                    type,
-                    explicitType: explicitType,
-                    sourceTree: sourceTree);
-                this.AddFileRefToGroup(fileRef);
-            }
+            var sourceTree = (relativePath != null) ? FileReference.ESourceTree.SourceRoot : FileReference.ESourceTree.Absolute;
+            var fileRef = this.Project.EnsureFileReferenceExists(
+                path,
+                relativePath,
+                type,
+                explicitType: explicitType,
+                sourceTree: sourceTree);
+            this.AddFileRefToGroup(fileRef);
         }
 
         public void

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -335,11 +335,8 @@ namespace XcodeBuilder
         EnsureHeaderFileExists(
             Bam.Core.TokenizedString path)
         {
-            lock (this)
-            {
-                var relativePath = this.Project.GetRelativePathToProject(path);
-                this.EnsureFileOfTypeExists(path, FileReference.EFileType.HeaderFile, relativePath: relativePath);
-            }
+            var relativePath = this.Project.GetRelativePathToProject(path);
+            this.EnsureFileOfTypeExists(path, FileReference.EFileType.HeaderFile, relativePath: relativePath);
         }
 
         public void
@@ -387,7 +384,7 @@ namespace XcodeBuilder
         Requires(
             Target other)
         {
-            lock (this)
+            lock (this.ProposedTargetDependencies)
             {
                 this.ProposedTargetDependencies.AddUnique(other);
             }

--- a/packages/XcodeBuilder/bam/Scripts/Target.cs
+++ b/packages/XcodeBuilder/bam/Scripts/Target.cs
@@ -707,7 +707,7 @@ namespace XcodeBuilder
                 project.EnsureProjectConfigurationExists(module);
 
                 var newConfig = new Configuration(module.BuildEnvironment.Configuration, project, this);
-                project.AllConfigurations.Add(newConfig);
+                project.appendAllConfigurations(newConfig);
                 configList.AddConfiguration(newConfig);
 
                 var clangMeta = Bam.Core.Graph.Instance.PackageMetaData<Clang.MetaData>("Clang");

--- a/packages/XcodeBuilder/bam/Scripts/TargetDependency.cs
+++ b/packages/XcodeBuilder/bam/Scripts/TargetDependency.cs
@@ -42,7 +42,7 @@ namespace XcodeBuilder
             this.Dependency = dependency;
             this.Proxy = proxy;
 
-            project.TargetDependencies.AddUnique(this);
+            project.appendTargetDependency(this);
         }
 
         public TargetDependency(
@@ -55,7 +55,7 @@ namespace XcodeBuilder
             this.Dependency = null;
             this.Proxy = proxy;
 
-            project.TargetDependencies.AddUnique(this);
+            project.appendTargetDependency(this);
         }
 
         public Target Dependency

--- a/packages/XcodeBuilder/bam/Scripts/WorkspaceMeta.cs
+++ b/packages/XcodeBuilder/bam/Scripts/WorkspaceMeta.cs
@@ -76,7 +76,7 @@ namespace XcodeBuilder
                     var target = new Target(module, project);
                     this.TargetMap.Add(moduleType, target);
 
-                    project.Targets.Add(moduleType, target);
+                    project.appendTarget(target);
                 }
             }
             if (null == module.MetaData)


### PR DESCRIPTION
Fixes #380. Eliminating 'lock (this)' expressions and hardening Xcode generation thread safety. THIS IS A BREAKING CHANGE.

'lock (this)' is considered bad for synchronisation, as the caller may also lock the object. Instances of these have been eliminated, either by replacing with a reduced scope lock on private only objects, or using System.Lazy<T> or System.Threading.LazyInitializer for thread-safe object initialization.

Many properties of XcodeBuilder.Project that were public are now private, but with new public accessors containing appropriate synchronisation.

XcodeBuilder.Target.Type is no longer public. The setter for this may have been used by external code, so this may cause compiler errors. There is now a public accessor, XcodeBuilder.Target.SetType() to use instead.