### PR TITLE
Issue449 merge

### DIFF
--- a/Bam/bam
+++ b/Bam/bam
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-curPath=$(dirname ${BASH_SOURCE[0]})
+curPath=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [ "$OSTYPE" == "msys" ] || [ "$OSTYPE" == "cygwin" ]; then
 
-exec $curPath/bam.exe $@
+exec "$curPath"/bam.exe $@
 
 else
 
@@ -43,6 +43,6 @@ then
     fi
 fi
 
-exec mono $monoargs $curPath/bam.exe $args
+exec mono $monoargs "$curPath"/bam.exe $args
 
 fi

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,5 @@
+08-Jun-2018 Fixes #449. Guard against spaces in the path that BuildAMation is installed/cloned in. Also, environment scripts (env.bat/env.sh) can be run from any directory now.
+
 13-May-2018 ======== Version 1.1.7 Release ========
 
 13-May-2018 Fixes #439. VisualC-15.0 is now compatible with the latest VisualStudio 2017 15.7 release.

--- a/env.bat
+++ b/env.bat
@@ -10,16 +10,16 @@ IF NOT "%1"=="" (
   SET flavour=%DefaultFlavour%
 )
 
-SET ExecutablePath=%CD%\bin\%flavour%
+SET ExecutablePath=%~dp0bin\%flavour%
 REM Using delayed expansion in case PATH has some spaces in
 SET NewPath=!PATH!
 
 REM Export the PATH
-IF NOT EXIST %ExecutablePath% (
-  ECHO *** ERROR: BuildAMation directory '%ExecutablePath%' does not exist ***
+IF NOT EXIST !ExecutablePath! (
+  ECHO *** ERROR: BuildAMation directory '!ExecutablePath!' does not exist ***
 ) ELSE (
-  SET NewPath=%ExecutablePath%;!NewPath!
-  SET PATH=%ExecutablePath%;!PATH!
+  SET NewPath=!ExecutablePath!;!NewPath!
+  SET PATH=!ExecutablePath!;!PATH!
   bam --version
 )
 

--- a/env.sh
+++ b/env.sh
@@ -3,12 +3,12 @@
 DefaultFlavour=Release
 # use the incoming argument as the sub-directory, or fall back on the default
 flavour=${1:-$DefaultFlavour}
-ExecutablePath=$PWD/bin/$flavour
+curPath=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ExecutablePath="$curPath/bin/$flavour"
 
-if [ ! -d "$ExecutablePath" ]
-then
+if [ ! -d "$ExecutablePath" ]; then
   echo "*** ERROR: BuildAMation directory '$ExecutablePath' does not exist ***"
 else
-  export PATH=$ExecutablePath:$PATH
+  export PATH="$ExecutablePath":$PATH
   bam --version
 fi


### PR DESCRIPTION
Fixes #449. Guard against spaces in the path that BuildAMation is installed/cloned in. Also, environment scripts (env.bat/env.sh) can be run from any directory now.